### PR TITLE
Allow this gem to be installed under Rails 5

### DIFF
--- a/acts-as-tree-with-dotted-ids.gemspec
+++ b/acts-as-tree-with-dotted-ids.gemspec
@@ -32,16 +32,16 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<jeweler>, ["~> 0"])
       s.add_development_dependency(%q<sqlite3>, ["~> 0"])
-      s.add_runtime_dependency(%q<activerecord>, [">= 4.0.0", "~> 4.0"])
+      s.add_runtime_dependency(%q<activerecord>, [">= 5.0.0", "~> 5.0"])
     else
       s.add_dependency(%q<jeweler>, ["~> 0"])
       s.add_dependency(%q<sqlite3>, ["~> 0"])
-      s.add_dependency(%q<activerecord>, [">= 4.0.0", "~> 4.0"])
+      s.add_dependency(%q<activerecord>, [">= 5.0.0", "~> 5.0"])
     end
   else
     s.add_dependency(%q<jeweler>, ["~> 0"])
     s.add_dependency(%q<sqlite3>, ["~> 0"])
-    s.add_dependency(%q<activerecord>, [">= 4.0.0", "~> 4.0"])
+    s.add_dependency(%q<activerecord>, [">= 5.0.0", "~> 5.0"])
   end
 end
 

--- a/acts-as-tree-with-dotted-ids.gemspec
+++ b/acts-as-tree-with-dotted-ids.gemspec
@@ -32,16 +32,16 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<jeweler>, ["~> 0"])
       s.add_development_dependency(%q<sqlite3>, ["~> 0"])
-      s.add_runtime_dependency(%q<activerecord>, [">= 4.0.0", '< 6.0'])
+      s.add_runtime_dependency(%q<activerecord>, [">= 4.0.0", '< 7.0'])
     else
       s.add_dependency(%q<jeweler>, ["~> 0"])
       s.add_dependency(%q<sqlite3>, ["~> 0"])
-      s.add_dependency(%q<activerecord>, [">= 4.0.0", '< 6.0'])
+      s.add_dependency(%q<activerecord>, [">= 4.0.0", '< 7.0'])
     end
   else
     s.add_dependency(%q<jeweler>, ["~> 0"])
     s.add_dependency(%q<sqlite3>, ["~> 0"])
-    s.add_dependency(%q<activerecord>, [">= 4.0.0", '< 6.0'])
+    s.add_dependency(%q<activerecord>, [">= 4.0.0", '< 7.0'])
   end
 end
 

--- a/acts-as-tree-with-dotted-ids.gemspec
+++ b/acts-as-tree-with-dotted-ids.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "acts-as-tree-with-dotted-ids"
-  s.version = "1.2.0"
+  s.version = "1.3.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
@@ -32,16 +32,16 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<jeweler>, ["~> 0"])
       s.add_development_dependency(%q<sqlite3>, ["~> 0"])
-      s.add_runtime_dependency(%q<activerecord>, [">= 5.0.0", "~> 5.0"])
+      s.add_runtime_dependency(%q<activerecord>, [">= 4.0.0", '< 6.0'])
     else
       s.add_dependency(%q<jeweler>, ["~> 0"])
       s.add_dependency(%q<sqlite3>, ["~> 0"])
-      s.add_dependency(%q<activerecord>, [">= 5.0.0", "~> 5.0"])
+      s.add_dependency(%q<activerecord>, [">= 4.0.0", '< 6.0'])
     end
   else
     s.add_dependency(%q<jeweler>, ["~> 0"])
     s.add_dependency(%q<sqlite3>, ["~> 0"])
-    s.add_dependency(%q<activerecord>, [">= 5.0.0", "~> 5.0"])
+    s.add_dependency(%q<activerecord>, [">= 4.0.0", '< 6.0'])
   end
 end
 

--- a/acts-as-tree-with-dotted-ids.gemspec
+++ b/acts-as-tree-with-dotted-ids.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "acts-as-tree-with-dotted-ids"
-  s.version = "1.3.0"
+  s.version = "1.3.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]

--- a/lib/active_record/acts/tree_with_dotted_ids.rb
+++ b/lib/active_record/acts/tree_with_dotted_ids.rb
@@ -46,11 +46,12 @@ module ActiveRecord
         # * <tt>foreign_key</tt> - specifies the column name to use for tracking of the tree (default: +parent_id+)
         # * <tt>order</tt> - makes it possible to sort the children according to this SQL snippet.
         # * <tt>counter_cache</tt> - keeps a count in a +children_count+ column if set to +true+ (default: +false+).
+        # * <tt>optional</tt> - makes the +belongs_to+ relationship optional if set to +true+ (default: +false+).
         def acts_as_tree_with_dotted_ids(options = {}, &b)
-          configuration = { :foreign_key => "parent_id", :order => nil, :counter_cache => nil }
+          configuration = { :foreign_key => "parent_id", :order => nil, :counter_cache => nil, :optional => false }
           configuration.update(options) if options.is_a?(Hash)
 
-          belongs_to :parent, :class_name => name, :foreign_key => configuration[:foreign_key], :counter_cache => configuration[:counter_cache]
+          belongs_to :parent, :class_name => name, :foreign_key => configuration[:foreign_key], :counter_cache => configuration[:counter_cache], optional: configuration[:optional]
 
 
           has_many :children, -> { order(configuration[:order]) }, :class_name => name, :foreign_key => configuration[:foreign_key],


### PR DESCRIPTION
These changes simply update the gemspec to allow the gem to be used under Rails 5. It would obviously be to you to build and distribute a new gem, but it should (?!) work effortlessly.
